### PR TITLE
Replace ftp:// with https:// for user convenience

### DIFF
--- a/data-access/data-download.md
+++ b/data-access/data-download.md
@@ -2,7 +2,7 @@
 
 You can get all data from Open Targets Genetics via:
 
-* EMBL-EBI FTP, database [Open Targets Genetics](ftp://ftp.ebi.ac.uk/pub/databases/opentargets/genetics/)
+* EMBL-EBI FTP, database [Open Targets Genetics](https://ftp.ebi.ac.uk/pub/databases/opentargets/genetics/)
 * Google BigQuery, project [open-targets-genetics:genetics](https://console.cloud.google.com/bigquery?project=open-targets-genetics\&p=open-targets-genetics\&d=genetics\&page=dataset)
 * [Google Cloud Storage](https://console.cloud.google.com/storage/browser/open-targets-genetics-releases?project=open-targets-genetics\&folder\&organizationId) (GCS) paywalled public bucket
 


### PR DESCRIPTION
Closes https://github.com/opentargets/issues/issues/3133.

Following Cote's message in Slack on the 25th of October: because the link is ftp://, most browsers don't open it and display a message prompting the user to open it in external application, which is likely confusing for the overall majority of the user base:
![image](https://github.com/opentargets/genetics-docs/assets/10669118/a64ac06c-d849-4e21-95d9-558c3f39c192)

The https:// link works and can be opened in a browser:
![image](https://github.com/opentargets/genetics-docs/assets/10669118/2908add7-c817-4641-b838-c08fb972a005)